### PR TITLE
Allow to be installed on Windows and MacOS with libhdf5 version 1.12 and 1.14

### DIFF
--- a/src/__H5E__.cc
+++ b/src/__H5E__.cc
@@ -151,10 +151,10 @@ DEFUN_DLD(__H5E_get_msg__, args, nargout,
 
   ssize_t nret = H5Eget_msg (msg_id, &type, msg, sz);
 
-  printf ("ID is %ld, nret is %ld, msg is %s\n", msg_id, nret, msg);
+  printf ("ID is %lld, nret is %lld, msg is %s\n", msg_id, nret, msg);
 
   if (nret < 0)
-    error ("H5E.get_msg: unable to retrieve message for id %ld", msg_id);
+    error ("H5E.get_msg: unable to retrieve message for id %lld", msg_id);
 
   return retval.append (std::string (msg));
 }

--- a/src/__H5O__.cc
+++ b/src/__H5O__.cc
@@ -91,13 +91,19 @@ num_attrs; /* # of attributes attached to object \n\
   // Infor structur output
   H5O_info_t oinfo;
 
+#if ((H5_VERS_MAJOR * 1000) + H5_VERS_MINOR) <= 1010
   if (H5Oget_info_by_name1 (loc_id, name.c_str (), &oinfo, lapl_id) < 0)
+#else
+  if (H5Oget_info_by_name3 (loc_id, name.c_str (), &oinfo, 0xFFFFFFFF, lapl_id) < 0)
+#endif
     error ("H5O_info2_t *oinfo: unable to get object info");
 
   // Build ouput structure
   octave_scalar_map info_struct;
   info_struct.assign ("fileno", octave_int64 (oinfo.fileno));
+#if ((H5_VERS_MAJOR * 1000) + H5_VERS_MINOR) <= 1010
   info_struct.assign ("addr", octave_int64 (oinfo.addr));
+#endif
   info_struct.assign ("type", octave_int64 (oinfo.type));
   info_struct.assign ("rc", octave_int64 (oinfo.rc));
   info_struct.assign ("atime", octave_int64 (oinfo.atime));

--- a/src/__H5R__.cc
+++ b/src/__H5R__.cc
@@ -80,8 +80,13 @@ references and should be set to -1 if the reference is an object reference,\n\
 
       int64NDArray out(dim_vector (1,nref));
 
+#if ((H5_VERS_MAJOR * 1000) + H5_VERS_MINOR) <= 1010
       for (int ii = 0; ii < nref; ii++)
         out(ii) = ref[ii];
+#else
+      for (int ii = 0; ii < nref; ii++)
+        out(ii) = ref.__data[ii];
+#endif
 
       retval.append (out);
     }

--- a/src/h5info.m
+++ b/src/h5info.m
@@ -66,12 +66,8 @@
 ## @seealso{h5readatt}
 ## @end deftypefn
 
-## PKG_ADD: if(exist(fullfile (fileparts (mfilename ("fullpath")), "testdir"), 'dir'))
-## PKG_ADD:     addpath (fullfile (fileparts (mfilename ("fullpath")), "testdir"));
-## PKG_ADD: end
-## PKG_DEL: if(exist(fullfile (fileparts (mfilename ("fullpath")), "testdir"), 'dir'))
-## PKG_DEL:     rmpath (fullfile (fileparts (mfilename ("fullpath")), "testdir"));
-## PKG_ADD: end
+## PKG_ADD: if(exist(fullfile (fileparts (mfilename ("fullpath")), "testdir"), 'dir')) addpath (fullfile (fileparts (mfilename ("fullpath")), "testdir")); end
+## PKG_DEL: if(exist(fullfile (fileparts (mfilename ("fullpath")), "testdir"), 'dir')) rmpath (fullfile (fileparts (mfilename ("fullpath")), "testdir")); end
 function s = h5info (fname, obj_name = "/")
 
   if (! exist ("fname", "var"))

--- a/src/h5info.m
+++ b/src/h5info.m
@@ -66,8 +66,12 @@
 ## @seealso{h5readatt}
 ## @end deftypefn
 
-## PKG_ADD: addpath (fullfile (fileparts (mfilename ("fullpath")), "testdir"));
-## PKG_DEL: rmpath (fullfile (fileparts (mfilename ("fullpath")), "testdir"));
+## PKG_ADD: if(exist(fullfile (fileparts (mfilename ("fullpath")), "testdir"), 'dir'))
+## PKG_ADD:     addpath (fullfile (fileparts (mfilename ("fullpath")), "testdir"));
+## PKG_ADD: end
+## PKG_DEL: if(exist(fullfile (fileparts (mfilename ("fullpath")), "testdir"), 'dir'))
+## PKG_DEL:     rmpath (fullfile (fileparts (mfilename ("fullpath")), "testdir"));
+## PKG_ADD: end
 function s = h5info (fname, obj_name = "/")
 
   if (! exist ("fname", "var"))

--- a/src/util/H5LT_c.h
+++ b/src/util/H5LT_c.h
@@ -15,7 +15,11 @@
 #ifndef H5LT_C_H
 #define H5LT_C_H
 
-#include <hdf5/serial/hdf5.h>
+#if defined(__APPLE__) || defined(_WIN32)
+    #include <hdf5.h>
+#else
+    #include <hdf5/serial/hdf5.h>
+#endif
 
 #include <octave/octave.h>
 #include <octave/parse.h>

--- a/src/util/h5_data_util.h
+++ b/src/util/h5_data_util.h
@@ -21,7 +21,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #define H5_DATA_UTIL_H
 
 #include <octave/octave.h>
-#include <hdf5/serial/hdf5.h>
+#if defined(__APPLE__) || defined(_WIN32)
+    #include <hdf5.h>
+#else
+    #include <hdf5/serial/hdf5.h>
+#endif
 
 #include "H5LT_c.h"
 

--- a/src/util/h5_oct_util.h
+++ b/src/util/h5_oct_util.h
@@ -23,7 +23,11 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #include <octave/octave.h>
 #include <octave/parse.h>
 
-#include <hdf5/serial/hdf5.h>
+#if defined(__APPLE__) || defined(_WIN32)
+    #include <hdf5.h>
+#else
+    #include <hdf5/serial/hdf5.h>
+#endif
 
 #include <set>
 #include <string>


### PR DESCRIPTION
With the following changes, I was able to install the package on 
- Octave 9.3 on an arm64 MacOS (libhdf5 version 1.14.5) and 
- Octave 8.2 on a Windows 10 machine (libhdf5 version 1.12.1)
